### PR TITLE
Fix build

### DIFF
--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -91,6 +91,8 @@ rm -rf ./target/linux/rockchip/patches-5.10/003-dt-bindings-net-add-RTL8152-bind
 cp -rf ../PATCH/rockchip-5.10/* ./target/linux/rockchip/patches-5.10/
 rm -rf ./package/firmware/linux-firmware/intel.mk
 cp -rf ../lede/package/firmware/linux-firmware/intel.mk ./package/firmware/linux-firmware/intel.mk
+rm -rf ./package/firmware/linux-firmware/mediatek.mk
+cp -rf ../lede/package/firmware/linux-firmware/mediatek.mk ./package/firmware/linux-firmware/mediatek.mk
 rm -rf ./package/firmware/linux-firmware/Makefile
 cp -rf ../lede/package/firmware/linux-firmware/Makefile ./package/firmware/linux-firmware/Makefile
 mkdir -p target/linux/rockchip/files-5.10


### PR DESCRIPTION
The path to mt7601u has changed after updating Linux-firmware 0515
https://github.com/coolsnowwolf/lede/commit/7640b82748f0afdb05627d198080ec5090a0f631

And what's new about the branch v23.05?
https://github.com/openwrt/openwrt/tree/openwrt-23.05