### PR TITLE
add back get_random_u32_below function

### DIFF
--- a/PATCH/BBRv3/kernel/009-0007-random-use-rejection-sampling-for-uniform-bounded-random.patch
+++ b/PATCH/BBRv3/kernel/009-0007-random-use-rejection-sampling-for-uniform-bounded-random.patch
@@ -1,0 +1,135 @@
+From e9a688bcb19348862afe30d7c85bc37c4c293471 Mon Sep 17 00:00:00 2001
+From: "Jason A. Donenfeld" <Jason@zx2c4.com>
+Date: Sat, 8 Oct 2022 20:42:54 -0600
+Subject: [PATCH] random: use rejection sampling for uniform bounded random
+ integers
+
+Until the very recent commits, many bounded random integers were
+calculated using `get_random_u32() % max_plus_one`, which not only
+incurs the price of a division -- indicating performance mostly was not
+a real issue -- but also does not result in a uniformly distributed
+output if max_plus_one is not a power of two. Recent commits moved to
+using `prandom_u32_max(max_plus_one)`, which replaces the division with
+a faster multiplication, but still does not solve the issue with
+non-uniform output.
+
+For some users, maybe this isn't a problem, and for others, maybe it is,
+but for the majority of users, probably the question has never been
+posed and analyzed, and nobody thought much about it, probably assuming
+random is random is random. In other words, the unthinking expectation
+of most users is likely that the resultant numbers are uniform.
+
+So we implement here an efficient way of generating uniform bounded
+random integers. Through use of compile-time evaluation, and avoiding
+divisions as much as possible, this commit introduces no measurable
+overhead. At least for hot-path uses tested, any potential difference
+was lost in the noise. On both clang and gcc, code generation is pretty
+small.
+
+The new function, get_random_u32_below(), lives in random.h, rather than
+prandom.h, and has a "get_random_xxx" function name, because it is
+suitable for all uses, including cryptography.
+
+In order to be efficient, we implement a kernel-specific variant of
+Daniel Lemire's algorithm from "Fast Random Integer Generation in an
+Interval", linked below. The kernel's variant takes advantage of
+constant folding to avoid divisions entirely in the vast majority of
+cases, works on both 32-bit and 64-bit architectures, and requests a
+minimal amount of bytes from the RNG.
+
+Link: https://arxiv.org/pdf/1805.10941.pdf
+Cc: stable@vger.kernel.org # to ease future backports that use this api
+Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
+---
+ drivers/char/random.c   | 22 ++++++++++++++++++++++
+ include/linux/prandom.h | 18 ++----------------
+ include/linux/random.h  | 40 ++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 64 insertions(+), 16 deletions(-)
+
+--- a/drivers/char/random.c
++++ b/drivers/char/random.c
+@@ -199,6 +199,7 @@ static void __cold process_random_ready_
+  *
+  *	void get_random_bytes(void *buf, size_t len)
+  *	u32 get_random_u32()
++ *	u32 get_random_u32_below(u32 ceil)
+  *	u64 get_random_u64()
+  *	unsigned int get_random_int()
+  *	unsigned long get_random_long()
+@@ -553,6 +554,27 @@ EXPORT_SYMBOL(get_random_ ##type);
+ DEFINE_BATCHED_ENTROPY(u64)
+ DEFINE_BATCHED_ENTROPY(u32)
+ 
++u32 __get_random_u32_below(u32 ceil)
++{
++	/*
++	 * This is the slow path for variable ceil. It is still fast, most of
++	 * the time, by doing traditional reciprocal multiplication and
++	 * opportunistically comparing the lower half to ceil itself, before
++	 * falling back to computing a larger bound, and then rejecting samples
++	 * whose lower half would indicate a range indivisible by ceil. The use
++	 * of `-ceil % ceil` is analogous to `2^32 % ceil`, but is computable
++	 * in 32-bits.
++	 */
++	u64 mult = (u64)ceil * get_random_u32();
++	if (unlikely((u32)mult < ceil)) {
++		u32 bound = -ceil % ceil;
++		while (unlikely((u32)mult < bound))
++			mult = (u64)ceil * get_random_u32();
++	}
++	return mult >> 32;
++}
++EXPORT_SYMBOL(__get_random_u32_below);
++
+ #ifdef CONFIG_SMP
+ /*
+  * This function is called when the CPU is coming up, with entry
+--- a/include/linux/random.h
++++ b/include/linux/random.h
+@@ -45,6 +45,46 @@ static inline unsigned long get_random_l
+ #endif
+ }
+ 
++u32 __get_random_u32_below(u32 ceil);
++
++/*
++ * Returns a random integer in the interval [0, ceil), with uniform
++ * distribution, suitable for all uses. Fastest when ceil is a constant, but
++ * still fast for variable ceil as well.
++ */
++static inline u32 get_random_u32_below(u32 ceil)
++{
++	if (!__builtin_constant_p(ceil))
++		return __get_random_u32_below(ceil);
++
++	/*
++	 * For the fast path, below, all operations on ceil are precomputed by
++	 * the compiler, so this incurs no overhead for checking pow2, doing
++	 * divisions, or branching based on integer size. The resultant
++	 * algorithm does traditional reciprocal multiplication (typically
++	 * optimized by the compiler into shifts and adds), rejecting samples
++	 * whose lower half would indicate a range indivisible by ceil.
++	 */
++	BUILD_BUG_ON_MSG(!ceil, "get_random_u32_below() must take ceil > 0");
++	if (ceil <= 1)
++		return 0;
++	for (;;) {
++		if (ceil <= 1U << 8) {
++			u32 mult = ceil * (get_random_u32() & 0xff);
++			if (likely(is_power_of_2(ceil) || (u8)mult >= (1U << 8) % ceil))
++				return mult >> 8;
++		} else if (ceil <= 1U << 16) {
++			u32 mult = ceil * (get_random_u32() & 0xffff);
++			if (likely(is_power_of_2(ceil) || (u16)mult >= (1U << 16) % ceil))
++				return mult >> 16;
++		} else {
++			u64 mult = (u64)ceil * get_random_u32();
++			if (likely(is_power_of_2(ceil) || (u32)mult >= -ceil % ceil))
++				return mult >> 32;
++		}
++	}
++}
++
+ /*
+  * On 64-bit architectures, protect against non-terminated C string overflows
+  * by zeroing out the first byte of the canary; this leaves 56 bits of entropy.

--- a/PATCH/BBRv3/kernel/010-bbr3-0016-net-tcp_bbr-v3-update-TCP-bbr-congestion-control-mod.patch
+++ b/PATCH/BBRv3/kernel/010-bbr3-0016-net-tcp_bbr-v3-update-TCP-bbr-congestion-control-mod.patch
@@ -1949,10 +1949,10 @@ Signed-off-by: Alexandre Frade <kernel@xanmod.org>
 +
 +	/* Decide the random round-trip bound for wait until probe: */
 +	bbr->rounds_since_probe =
-+		prandom_u32_max(bbr_param(sk, bw_probe_rand_rounds));
++		get_random_u32_below(bbr_param(sk, bw_probe_rand_rounds));
 +	/* Decide the random wall clock bound for wait until probe: */
 +	bbr->probe_wait_us = bbr_param(sk, bw_probe_base_us) +
-+			     prandom_u32_max(bbr_param(sk, bw_probe_rand_us));
++			     get_random_u32_below(bbr_param(sk, bw_probe_rand_us));
 +}
 +
 +static void bbr_set_cycle_idx(struct sock *sk, int cycle_idx)


### PR DESCRIPTION
I haven't compiled it yet. I don't know if there are any other functions missing.
There should be no problem
Why not try merging and compiling first?