### PR TITLE
r2s squashfs use lz4hc

### DIFF
--- a/PATCH/squashfs4_add_zstd_lz4_support.patch
+++ b/PATCH/squashfs4_add_zstd_lz4_support.patch
@@ -1,0 +1,62 @@
+diff --git a/include/image.mk b/include/image.mk
+index 9a4dff2167..c90e7b3441
+--- a/include/image.mk
++++ b/include/image.mk
+@@ -94,6 +94,12 @@ ifeq ($(CONFIG_SQUASHFS_XZ),y)
+   endif
+   SQUASHFSCOMP := xz $(LZMA_XZ_OPTIONS) $(BCJ_FILTER)
+ endif
++ifeq ($(CONFIG_SQUASHFS_ZSTD),y)
++  SQUASHFSCOMP := zstd -Xcompression-level 15
++endif
++ifeq ($(CONFIG_SQUASHFS_LZ4),y)
++  SQUASHFSCOMP := lz4 -Xhc
++endif
+ 
+ JFFS2_BLOCKSIZE ?= 64k 128k
+ 
+diff --git a/tools/Makefile b/tools/Makefile
+index b16c5d9c5b..9fb097bb17
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -128,7 +128,7 @@ $(curdir)/pkgconf/compile := $(curdir)/meson/compile
+ $(curdir)/quilt/compile := $(curdir)/autoconf/compile $(curdir)/findutils/compile
+ $(curdir)/sdcc/compile := $(curdir)/bison/compile
+ $(curdir)/squashfs3-lzma/compile := $(curdir)/lzma-old/compile
+-$(curdir)/squashfs4/compile := $(curdir)/xz/compile $(curdir)/zlib/compile
++$(curdir)/squashfs4/compile := $(curdir)/xz/compile $(curdir)/zlib/compile $(curdir)/zstd/compile $(curdir)/lz4/compile
+ $(curdir)/util-linux/compile := $(curdir)/bison/compile $(curdir)/automake/compile
+ $(curdir)/yafut/compile := $(curdir)/cmake/compile
+ 
+diff --git a/tools/squashfs4/Makefile b/tools/squashfs4/Makefile
+index 38c3e5233f..b79c445806
+--- a/tools/squashfs4/Makefile
++++ b/tools/squashfs4/Makefile
+@@ -8,14 +8,12 @@ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=squashfs4
+ PKG_CPE_ID:=cpe:/a:phillip_lougher:squashfs
+-PKG_VERSION:=4.6.1
+-PKG_RELEASE=3
++PKG_VERSION:=master
++PKG_RELEASE=1
+ 
+ PKG_SOURCE_PROTO:=git
+ PKG_SOURCE_URL:=https://github.com/plougher/squashfs-tools
+-PKG_SOURCE_DATE:=2023-03-26
+-PKG_SOURCE_VERSION:=d8cb82d9840330f9344ec37b992595b5d7b44184
+-PKG_MIRROR_HASH:=e84026de1ab187f3f76d1b781a29259d818f887e1651225f850a62d6f90b1b9e
++PKG_SOURCE_VERSION:=fc71116d648b51525e8c29a31f56a1c510529458
+ 
+ HOST_BUILD_PARALLEL:=1
+ 
+@@ -27,6 +25,9 @@ define Host/Compile
+ 		XZ_SUPPORT=1 \
+ 		LZMA_XZ_SUPPORT=1 \
+ 		XZ_EXTENDED_OPTIONS=1 \
++		ZSTD_SUPPORT=1 \
++		LZ4_SUPPORT=1 \
++		LZO_SUPPORT=0 \
+ 		EXTRA_CFLAGS="-I$(STAGING_DIR_HOST)/include" \
+ 		mksquashfs unsquashfs
+ endef

--- a/SCRIPTS/R2S/02_target_only.sh
+++ b/SCRIPTS/R2S/02_target_only.sh
@@ -23,4 +23,16 @@ cp -rf ../PATCH/files ./files
 find ./ -name *.orig | xargs rm -f
 find ./ -name *.rej | xargs rm -f
 
+# 使用 LZ4HC 压缩算法，优化设备性能
+# 也支持CONFIG_SQUASHFS_ZSTD=y
+if patch -p1 < ../PATCH/squashfs4_add_zstd_lz4_support.patch; then
+  rm -rf ./tools/squashfs4/patches/
+  echo '
+CONFIG_SQUASHFS_XZ=n
+CONFIG_SQUASHFS_LZ4=y
+CONFIG_LZ4_DECOMPRESS=y
+' | tee -a ./target/linux/generic/config-6.6 ./target/linux/rockchip/armv8/config-6.6 > /dev/null
+else
+  echo "squashfs 补丁应用失败，跳过"
+fi
 #exit 0


### PR DESCRIPTION
squashfs-tools 已经默认支持新的压缩算法 https://github.com/plougher/squashfs-tools/commit/fc71116d648b51525e8c29a31f56a1c510529458 ，openwrt未启用，默认使用的是 xz 9 级别压缩固件。
使用 lz4hc 可以在低端设备上获得性能提升，在r2s上测试正常
也可选使用 ZSTD 压缩算法
