### PR TITLE
ci(workflows): 手动触发 OpenWrt-Matrix 时也同步徽章

### DIFF
--- a/.github/workflows/OpenWrt-Matrix.yml
+++ b/.github/workflows/OpenWrt-Matrix.yml
@@ -99,7 +99,7 @@ jobs:
           echo "matrix.arch: '${{ matrix.arch }}'"
           echo "matrix.arch_suffix: '${{ matrix.arch_suffix }}'"
           echo "github.run_id: '${{ github.run_id }}'"
-          
+
           # Platform name in lowercase
           name_lower=$(echo "${{ matrix.name }}" | tr 'A-Z' 'a-z')
 
@@ -306,3 +306,12 @@ jobs:
 
       - name: Print Disk Space After
         run: df -h
+
+      - name: Trigger badge sync for current platform
+        if: github.workflow == 'OpenWrt-Matrix' && inputs.build_firmware && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering badge sync for ${{ matrix.name }} with status: ${{ steps.create_release.outcome }}"
+          gh workflow run "${{ matrix.name }}-OpenWrt.yml" \
+            --field badge_status="${{ steps.create_release.outcome }}" || echo "Failed to trigger ${{ matrix.name }} workflow"

--- a/.github/workflows/R2C-OpenWrt.yml
+++ b/.github/workflows/R2C-OpenWrt.yml
@@ -15,15 +15,32 @@ on:
         required: false
         type: boolean
         default: true
+      badge_status:
+        description: "badge status var（keep empty）"
+        required: false
+        type: string
+        default: ''
   watch:
     types: started
 
 jobs:
   build:
     uses: ./.github/workflows/OpenWrt-Matrix.yml
-    if: github.event.repository.owner.id == github.event.sender.id
+    if: github.event.repository.owner.id == github.event.sender.id && inputs.badge_status == ''
     with:
       targets: "R2C"
       upload_source: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_source }}
       build_firmware: ${{ (github.event_name == 'workflow_dispatch' && inputs.build_firmware) || github.event_name != 'workflow_dispatch' }}
-    
+
+  sync_badge:
+    if: inputs.badge_status != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync badge status
+        run: |
+          echo "Syncing badge status ...( ${{ inputs.badge_status }} )"
+          if [ "${{ inputs.badge_status }}" == "success" ]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/R2S-OpenWrt.yml
+++ b/.github/workflows/R2S-OpenWrt.yml
@@ -15,14 +15,32 @@ on:
         required: false
         type: boolean
         default: true
+      badge_status:
+        description: "badge status var（keep empty）"
+        required: false
+        type: string
+        default: ''
   watch:
     types: started
 
 jobs:
   build:
     uses: ./.github/workflows/OpenWrt-Matrix.yml
-    if: github.event.repository.owner.id == github.event.sender.id
+    if: github.event.repository.owner.id == github.event.sender.id && inputs.badge_status == ''
     with:
       targets: "R2S"
       upload_source: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_source }}
       build_firmware: ${{ (github.event_name == 'workflow_dispatch' && inputs.build_firmware) || github.event_name != 'workflow_dispatch' }}
+
+  sync_badge:
+    if: inputs.badge_status != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync badge status
+        run: |
+          echo "Syncing badge status ...( ${{ inputs.badge_status }} )"
+          if [ "${{ inputs.badge_status }}" == "success" ]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/R3S-OpenWrt.yml
+++ b/.github/workflows/R3S-OpenWrt.yml
@@ -15,15 +15,32 @@ on:
         required: false
         type: boolean
         default: true
+      badge_status:
+        description: "badge status var（keep empty）"
+        required: false
+        type: string
+        default: ''
   watch:
     types: started
 
 jobs:
   build:
     uses: ./.github/workflows/OpenWrt-Matrix.yml
-    if: github.event.repository.owner.id == github.event.sender.id
+    if: github.event.repository.owner.id == github.event.sender.id && inputs.badge_status == ''
     with:
       targets: "R3S"
       upload_source: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_source }}
       build_firmware: ${{ (github.event_name == 'workflow_dispatch' && inputs.build_firmware) || github.event_name != 'workflow_dispatch' }}
-    
+
+  sync_badge:
+    if: inputs.badge_status != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync badge status
+        run: |
+          echo "Syncing badge status ...( ${{ inputs.badge_status }} )"
+          if [ "${{ inputs.badge_status }}" == "success" ]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/R4S-OpenWrt.yml
+++ b/.github/workflows/R4S-OpenWrt.yml
@@ -15,14 +15,32 @@ on:
         required: false
         type: boolean
         default: true
+      badge_status:
+        description: "badge status var（keep empty）"
+        required: false
+        type: string
+        default: ''
   watch:
     types: started
 
 jobs:
   build:
     uses: ./.github/workflows/OpenWrt-Matrix.yml
-    if: github.event.repository.owner.id == github.event.sender.id
+    if: github.event.repository.owner.id == github.event.sender.id && inputs.badge_status == ''
     with:
       targets: "R4S"
       upload_source: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_source }}
       build_firmware: ${{ (github.event_name == 'workflow_dispatch' && inputs.build_firmware) || github.event_name != 'workflow_dispatch' }}
+
+  sync_badge:
+    if: inputs.badge_status != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync badge status
+        run: |
+          echo "Syncing badge status ...( ${{ inputs.badge_status }} )"
+          if [ "${{ inputs.badge_status }}" == "success" ]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/X86-OpenWrt.yml
+++ b/.github/workflows/X86-OpenWrt.yml
@@ -15,15 +15,32 @@ on:
         required: false
         type: boolean
         default: true
+      badge_status:
+        description: "badge status var（keep empty）"
+        required: false
+        type: string
+        default: ''
   watch:
     types: started
 
 jobs:
   build:
     uses: ./.github/workflows/OpenWrt-Matrix.yml
-    if: github.event.repository.owner.id == github.event.sender.id
+    if: github.event.repository.owner.id == github.event.sender.id && inputs.badge_status == ''
     with:
       targets: "X86"
       upload_source: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_source }}
       build_firmware: ${{ (github.event_name == 'workflow_dispatch' && inputs.build_firmware) || github.event_name != 'workflow_dispatch' }}
-    
+
+  sync_badge:
+    if: inputs.badge_status != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync badge status
+        run: |
+          echo "Syncing badge status ...( ${{ inputs.badge_status }} )"
+          if [ "${{ inputs.badge_status }}" == "success" ]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
如果是手动运行 `OpenWrt-Matrix.yml` ，主动同步各平台的 badge.svg 。之前只会在平台单独的工作流运行时更新状态。

通过传递构建结果，平台工作流中的新 `sync_badge` 作业会相应地成功或失败。这确保了每个平台的徽章能够准确显示其在矩阵构建中的最新状态。