### PR TITLE
build(scripts): dynamically detect kernel version

### DIFF
--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -7,6 +7,13 @@ sed -i 's/Os/O2/g' include/target.mk
 # 更新 Feeds
 ./scripts/feeds update -a
 ./scripts/feeds install -a
+# 提取内核版本
+export KERNEL_VERSION=$(sed -n 's/^KERNEL_PATCHVER:=//p' ./target/linux/rockchip/Makefile) # 如 6.12
+if [ -z "$KERNEL_VERSION" ]; then
+    echo "Error: Failed to extract KERNEL_VERSION from ./target/linux/rockchip/Makefile" >&2
+    exit 1
+fi
+echo "KERNEL_VERSION=${KERNEL_VERSION}" | tee -a "$GITHUB_ENV"
 # 移除 SNAPSHOT 标签
 sed -i 's,-SNAPSHOT,,g' include/version.mk
 sed -i 's,-SNAPSHOT,,g' package/base-files/image-config.in
@@ -38,11 +45,11 @@ cp -rf ../openwrt_ma/package/network/config/firewall4 ./package/network/config/f
 
 ### 必要的 Patches ###
 # Patch arm64 型号名称
-cp -rf ../PATCH/kernel/arm/* ./target/linux/generic/hack-6.12/
+cp -rf ../PATCH/kernel/arm/* ./target/linux/generic/hack-${KERNEL_VERSION}/
 # BBRv3
-cp -rf ../PATCH/kernel/bbr3/* ./target/linux/generic/backport-6.12/
+cp -rf ../PATCH/kernel/bbr3/* ./target/linux/generic/backport-${KERNEL_VERSION}/
 # LRNG
-cp -rf ../PATCH/kernel/lrng/* ./target/linux/generic/hack-6.12/
+cp -rf ../PATCH/kernel/lrng/* ./target/linux/generic/hack-${KERNEL_VERSION}/
 echo '
 # CONFIG_RANDOM_DEFAULT_IMPL is not set
 CONFIG_LRNG=y
@@ -53,19 +60,19 @@ CONFIG_LRNG_CPU=y
 # CONFIG_LRNG_SCHED is not set
 CONFIG_LRNG_SELFTEST=y
 # CONFIG_LRNG_SELFTEST_PANIC is not set
-' >>./target/linux/generic/config-6.12
+' >>./target/linux/generic/config-${KERNEL_VERSION}
 # wg
-cp -rf ../PATCH/kernel/wg/* ./target/linux/generic/hack-6.12/
+cp -rf ../PATCH/kernel/wg/* ./target/linux/generic/hack-${KERNEL_VERSION}/
 # dont wrongly interpret first-time data
 echo "net.netfilter.nf_conntrack_tcp_max_retrans=5" >>./package/kernel/linux/files/sysctl-nf-conntrack.conf
 # OTHERS
-cp -rf ../PATCH/kernel/others/* ./target/linux/generic/pending-6.12/
+cp -rf ../PATCH/kernel/others/* ./target/linux/generic/pending-${KERNEL_VERSION}/
 # luci-app-attendedsysupgrade
 sed -i '/luci-app-attendedsysupgrade/d' feeds/luci/collections/luci-nginx/Makefile
 
 ### Fullcone-NAT 部分 ###
 # bcmfullcone
-cp -rf ../PATCH/kernel/bcmfullcone/* ./target/linux/generic/hack-6.12/
+cp -rf ../PATCH/kernel/bcmfullcone/* ./target/linux/generic/hack-${KERNEL_VERSION}/
 # set nf_conntrack_expect_max for fullcone
 wget -qO - https://github.com/openwrt/openwrt/commit/bbf39d07.patch | patch -p1
 echo "net.netfilter.nf_conntrack_helper = 1" >>./package/kernel/linux/files/sysctl-nf-conntrack.conf
@@ -84,8 +91,8 @@ popd
 
 ### Shortcut-FE 部分 ###
 # Patch Kernel 以支持 Shortcut-FE
-cp -rf ../PATCH/kernel/sfe/* ./target/linux/generic/hack-6.12/
-cp -rf ../lede/target/linux/generic/pending-6.12/613-netfilter_optional_tcp_window_check.patch ./target/linux/generic/pending-6.12/613-netfilter_optional_tcp_window_check.patch
+cp -rf ../PATCH/kernel/sfe/* ./target/linux/generic/hack-${KERNEL_VERSION}/
+cp -rf ../lede/target/linux/generic/pending-${KERNEL_VERSION}/613-netfilter_optional_tcp_window_check.patch ./target/linux/generic/pending-${KERNEL_VERSION}/613-netfilter_optional_tcp_window_check.patch
 # Patch LuCI 以增添 Shortcut-FE 开关
 pushd feeds/luci
 patch -p1 <../../../PATCH/pkgs/firewall/luci/0002-luci-app-firewall-add-shortcut-fe-option.patch
@@ -118,9 +125,9 @@ popd
 # make olddefconfig
 wget -qO - https://github.com/openwrt/openwrt/commit/c21a3570.patch | patch -p1
 # igc-fix
-cp -rf ../lede/target/linux/x86/patches-6.12/996-intel-igc-i225-i226-disable-eee.patch ./target/linux/x86/patches-6.12/996-intel-igc-i225-i226-disable-eee.patch
+cp -rf ../lede/target/linux/x86/patches-${KERNEL_VERSION}/996-intel-igc-i225-i226-disable-eee.patch ./target/linux/x86/patches-${KERNEL_VERSION}/996-intel-igc-i225-i226-disable-eee.patch
 # btf
-cp -rf ../PATCH/kernel/btf/* ./target/linux/generic/hack-6.12/
+cp -rf ../PATCH/kernel/btf/* ./target/linux/generic/hack-${KERNEL_VERSION}/
 
 ### 获取额外的基础软件包 ###
 # Disable Mitigations
@@ -207,12 +214,11 @@ echo > ./feeds/packages/utils/watchcat/files/watchcat.config
 #sed -i "s/enabled '0'/enabled '1'/g" feeds/packages/utils/irqbalance/files/irqbalance.config
 
 # 使用 TEO CPU 空闲调度器
-KERNEL_VERSION="6.12"
 CONFIG_CONTENT='
 CONFIG_CPU_IDLE_GOV_MENU=n
 CONFIG_CPU_IDLE_GOV_TEO=y
 '
-# 查找所有与内核 6.12 相关的配置文件并将这些配置项追加到文件末尾
+# 查找所有与内核相关的配置文件并将这些配置项追加到文件末尾
 find ./target/linux/ -name "config-${KERNEL_VERSION}" | xargs -I{} sh -c "echo '$CONFIG_CONTENT' | tee -a {} > /dev/null"
 
 ### 最后的收尾工作 ###
@@ -221,6 +227,6 @@ mkdir -p package/base-files/files/usr/bin
 cp -rf ../OpenWrt-Add/fuck ./package/base-files/files/usr/bin/fuck
 # 生成默认配置及缓存
 rm -rf .config
-sed -i 's,CONFIG_WERROR=y,# CONFIG_WERROR is not set,g' target/linux/generic/config-6.12
+sed -i 's,CONFIG_WERROR=y,# CONFIG_WERROR is not set,g' target/linux/generic/config-${KERNEL_VERSION}
 
 #exit 0

--- a/SCRIPTS/R2S/02_target_only.sh
+++ b/SCRIPTS/R2S/02_target_only.sh
@@ -9,7 +9,7 @@ sed -i 's,"eth1" "eth0","eth0" "eth1",g' target/linux/rockchip/armv8/base-files/
 sed -i "s,'eth1' 'eth0','eth0' 'eth1',g" target/linux/rockchip/armv8/base-files/etc/board.d/02_network
 
 # remove LRNG for 3328
-rm -f target/linux/generic/hack-6.12/696*
+rm -f target/linux/generic/hack-${KERNEL_VERSION}/696*
 
 #Vermagic
 latest_version="$(curl -s https://github.com/openwrt/openwrt/tags | grep -Eo "v[0-9\.]+\-*r*c*[0-9]*.tar.gz" | sed -n '/[2-9][5-9]/p' | sed -n 1p | sed 's/v//g' | sed 's/.tar.gz//g')"


### PR DESCRIPTION
The scripts now extract the KERNEL_VERSION from target/linux/rockchip/Makefile and use this variable for applying kernel patches and configuration. This change removes hardcoded kernel version references (e.g., 6.12), improving maintainability and adaptability to future kernel updates.

脚本现在从target/linux/rockchip/Makefile中提取KERNEL_VERSION 并使用此变量来应用内核补丁和配置。这
更改删除了硬编码的内核版本引用（例如6.12），改进了
可维护性和对未来内核更新的适应性。